### PR TITLE
Added RenameField check to plugin

### DIFF
--- a/plugins/field_removal.py
+++ b/plugins/field_removal.py
@@ -1,16 +1,15 @@
 import tokenize
 
 TWI101 = 'TWI101 Unsafe field removal. See http://twil.io/f8-field-removal'
-DANGER_METHOD = 'RemoveField'
+DANGER_METHODS = ['RemoveField', 'RenameField']
 
 
 def checker(physical_line, tokens):
-    if DANGER_METHOD not in physical_line:
-        return
-
-    for token_type, text, start, _, _ in tokens:
-        if token_type == tokenize.NAME and text == DANGER_METHOD:
-            return (start[1], TWI101)
+    for danger_method in DANGER_METHODS:
+        if danger_method in physical_line:
+            for token_type, text, start, _, _ in tokens:
+                if token_type == tokenize.NAME and text in DANGER_METHODS:
+                    return (start[1], TWI101)
 
 
 checker.name = 'deved_field_removal'

--- a/tests/test_cases/field_removal.py
+++ b/tests/test_cases/field_removal.py
@@ -20,6 +20,16 @@ class Migration(migrations.Migration):
             model_name='productlandingpage',
             name='quickstart_java',
         ),
+        migrations.RenameField(
+            model_name='productlandingpage',
+            old_name='old_field_name_1',
+            new_name='new_field_name_1',
+        ),
+        migrations.RenameField(
+            model_name='productlandingpage',
+            old_name='old_field_name_2',
+            new_name='new_field_name_2',
+        ),
     ]
 
     foo = None

--- a/tests/test_field_removal.py
+++ b/tests/test_field_removal.py
@@ -12,8 +12,10 @@ class FieldRemovalPluginTestCase(unittest.TestCase):
     def testChecker(self):
         items = tokenize_and_invoke_checker(TESTCASE_FILENAME, checker)
 
-        self.assertEqual(len(items), 4)
+        self.assertEqual(len(items), 6)
         self.assertEqual(items[0], f'13:19: {TWI101}')
         self.assertEqual(items[1], f'17:19: {TWI101}')
         self.assertEqual(items[2], f'19:8: {TWI101}')
-        self.assertEqual(items[3], f'29:37: {TWI101}')
+        self.assertEqual(items[3], f'23:19: {TWI101}')
+        self.assertEqual(items[4], f'28:19: {TWI101}')
+        self.assertEqual(items[5], f'39:37: {TWI101}')


### PR DESCRIPTION
Slightly modified the `checker` method since we are using a list of _dangerous methods_ instead of just the one.
Added a couple of `RenameField` methods in the test file.
Modified test to make sense with the previous changes.